### PR TITLE
Ee 16843 paginated audit history

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ pipeline:
     commands:
       - docker build -t pttg-ip-audit .
     when:
-      branch: [master, refs/tags/*, EE-16843-paginated-audit-history-mandatory]
+      branch: [master, refs/tags/*]
       event: [push, tag]
 
   install-docker-image:
@@ -39,7 +39,7 @@ pipeline:
       - docker tag pttg-ip-audit quay.io/ukhomeofficedigital/pttg-ip-audit:build-$${DRONE_BUILD_NUMBER}
       - docker push quay.io/ukhomeofficedigital/pttg-ip-audit:build-$${DRONE_BUILD_NUMBER}
     when:
-      branch: [master, EE-16843-paginated-audit-history-mandatory]
+      branch: master
       event: push
 
   tag-docker-image-with-git-tag:
@@ -75,7 +75,7 @@ pipeline:
       - cd kube-pttg-ip-audit
       - ./deploy.sh
     when:
-      branch: [master, EE-16843-paginated-audit-history-mandatory]
+      branch: master
       event: [push, tag]
 
   deployment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,7 +15,7 @@ pipeline:
       - sh /root/git-utilities/set-up-github-user.sh "$${GITHUB_SSH_KEY}"
       - ./gradlew release -Prelease.useAutomaticVersion=true -x runBuildTasks
     when:
-      branch: [master, EE-16064-audit-history]
+      branch: [master]
       event: [push]
 
   docker-build:
@@ -25,7 +25,7 @@ pipeline:
     commands:
       - docker build -t pttg-ip-audit .
     when:
-      branch: [master, refs/tags/*, EE-16064-audit-history]
+      branch: [master, refs/tags/*, EE-16843-paginated-audit-history-mandatory]
       event: [push, tag]
 
   install-docker-image:
@@ -39,7 +39,7 @@ pipeline:
       - docker tag pttg-ip-audit quay.io/ukhomeofficedigital/pttg-ip-audit:build-$${DRONE_BUILD_NUMBER}
       - docker push quay.io/ukhomeofficedigital/pttg-ip-audit:build-$${DRONE_BUILD_NUMBER}
     when:
-      branch: [master, EE-16064-audit-history]
+      branch: [master, EE-16843-paginated-audit-history-mandatory]
       event: push
 
   tag-docker-image-with-git-tag:
@@ -75,7 +75,7 @@ pipeline:
       - cd kube-pttg-ip-audit
       - ./deploy.sh
     when:
-      branch: [master, EE-16064-audit-history]
+      branch: [master, EE-16843-paginated-audit-history-mandatory]
       event: [push, tag]
 
   deployment:

--- a/src/main/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepository.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepository.java
@@ -25,7 +25,7 @@ public interface AuditEntryJpaRepository extends PagingAndSortingRepository<Audi
     List<AuditEntry> findAllByOrderByTimestampDesc(Pageable pageable);
 
     @Query("SELECT audit FROM AuditEntry audit WHERE audit.timestamp <= :toDate AND audit.type in (:eventTypes) ORDER BY audit.timestamp")
-    List<AuditEntry> findAuditHistory(@Param("toDate") LocalDateTime toDate, @Param("eventTypes") List<AuditEventType> eventTypes);
+    List<AuditEntry> findAuditHistory(@Param("toDate") LocalDateTime toDate, @Param("eventTypes") List<AuditEventType> eventTypes, Pageable pageable);
 
 }
 

--- a/src/main/java/uk/gov/digital/ho/pttg/AuditHistoryService.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/AuditHistoryService.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.pttg;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import uk.gov.digital.ho.pttg.api.AuditRecord;
 
@@ -19,7 +20,7 @@ public class AuditHistoryService {
 
     public List<AuditRecord> getAuditHistory(LocalDate toDate, List<AuditEventType> eventTypes) {
         LocalDateTime toDateEod = toDate.atTime(23, 59, 59, 999);
-        List<AuditEntry> entries = repository.findAuditHistory(toDateEod, eventTypes);
+        List<AuditEntry> entries = repository.findAuditHistory(toDateEod, eventTypes, Pageable.unpaged());
         return entries.stream()
                 .map(AuditService::transformToAuditRecord)
                 .collect(Collectors.toList());

--- a/src/main/java/uk/gov/digital/ho/pttg/AuditHistoryService.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/AuditHistoryService.java
@@ -18,9 +18,9 @@ public class AuditHistoryService {
         this.repository = repository;
     }
 
-    public List<AuditRecord> getAuditHistory(LocalDate toDate, List<AuditEventType> eventTypes) {
+    public List<AuditRecord> getAuditHistory(LocalDate toDate, List<AuditEventType> eventTypes, Pageable pageable) {
         LocalDateTime toDateEod = toDate.atTime(23, 59, 59, 999);
-        List<AuditEntry> entries = repository.findAuditHistory(toDateEod, eventTypes, Pageable.unpaged());
+        List<AuditEntry> entries = repository.findAuditHistory(toDateEod, eventTypes, pageable);
         return entries.stream()
                 .map(AuditService::transformToAuditRecord)
                 .collect(Collectors.toList());

--- a/src/main/java/uk/gov/digital/ho/pttg/api/AuditHistoryResource.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/AuditHistoryResource.java
@@ -41,8 +41,6 @@ public class AuditHistoryResource {
                 toDate,
                 pageable,
                 value(EVENT, PTTG_AUDIT_HISTORY_REQUEST_RECEIVED));
-
-        pageable = useDefaultIfNull(pageable);
         toDate = useDefaultIfNull(toDate);
 
         List<AuditRecord> result = auditHistoryService.getAuditHistory(toDate, eventTypes, pageable);
@@ -58,9 +56,5 @@ public class AuditHistoryResource {
 
     private LocalDate useDefaultIfNull(LocalDate toDate) {
         return toDate != null ? toDate : LocalDate.now();
-    }
-
-    private Pageable useDefaultIfNull(Pageable pageable) {
-        return pageable != null ? pageable : Pageable.unpaged();
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/api/AuditHistoryResource.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/AuditHistoryResource.java
@@ -1,6 +1,7 @@
 package uk.gov.digital.ho.pttg.api;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,14 +32,20 @@ public class AuditHistoryResource {
     @GetMapping(value = "/history", produces = APPLICATION_JSON_VALUE)
     public List<AuditRecord> retrieveAuditHistory(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate,
-            @RequestParam List<AuditEventType> eventTypes
+            @RequestParam List<AuditEventType> eventTypes,
+            @RequestParam Pageable pageable
     ) {
-        log.info("Requested Audit History for events {} up to end date {}",
+
+        log.info("Requested Audit History for events {} up to end date {} with pageable of {}",
                 eventTypes,
                 toDate,
+                pageable,
                 value(EVENT, PTTG_AUDIT_HISTORY_REQUEST_RECEIVED));
 
-        List<AuditRecord> result = auditHistoryService.getAuditHistory(toDate, eventTypes);
+        pageable = useDefaultIfNull(pageable);
+        toDate = useDefaultIfNull(toDate);
+
+        List<AuditRecord> result = auditHistoryService.getAuditHistory(toDate, eventTypes, pageable);
 
         log.info("Returned {} audit record(s) for history request",
                 result.size(),
@@ -47,5 +54,13 @@ public class AuditHistoryResource {
         );
 
         return result;
+    }
+
+    private LocalDate useDefaultIfNull(LocalDate toDate) {
+        return toDate != null ? toDate : LocalDate.now();
+    }
+
+    private Pageable useDefaultIfNull(Pageable pageable) {
+        return pageable != null ? pageable : Pageable.unpaged();
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/api/AuditHistoryResource.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/AuditHistoryResource.java
@@ -31,9 +31,9 @@ public class AuditHistoryResource {
 
     @GetMapping(value = "/history", produces = APPLICATION_JSON_VALUE)
     public List<AuditRecord> retrieveAuditHistory(
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate,
             @RequestParam List<AuditEventType> eventTypes,
-            @RequestParam Pageable pageable
+            Pageable pageable
     ) {
 
         log.info("Requested Audit History for events {} up to end date {} with pageable of {}",

--- a/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryResourceIntTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryResourceIntTest.java
@@ -52,4 +52,26 @@ public class AuditHistoryResourceIntTest {
 
     }
 
+    @Test
+    public void shouldRetrieveAuditHistoryPaginated() throws JSONException {
+        String url = "/history?&eventTypes=INCOME_PROVING_FINANCIAL_STATUS_REQUEST,INCOME_PROVING_FINANCIAL_STATUS_RESPONSE&page=0&size=1";
+        String response = restTemplate.getForObject(url, String.class);
+
+        String firstId = JsonPath.read(response, "$[0].id");
+        String firstType = JsonPath.read(response, "$[0].ref");
+        assertThat(firstId).isEqualTo("some corr id");
+        assertThat(firstType).isEqualTo("INCOME_PROVING_FINANCIAL_STATUS_REQUEST");
+
+        url = "/history?&eventTypes=INCOME_PROVING_FINANCIAL_STATUS_REQUEST,INCOME_PROVING_FINANCIAL_STATUS_RESPONSE&page=1&size=1";
+        response = restTemplate.getForObject(url, String.class);
+        String secondId = JsonPath.read(response, "$[0].id");
+        String secondType = JsonPath.read(response, "$[0].ref");
+        assertThat(secondId).isEqualTo("some corr id");
+        assertThat(secondType).isEqualTo("INCOME_PROVING_FINANCIAL_STATUS_RESPONSE");
+
+        url = "/history?&eventTypes=INCOME_PROVING_FINANCIAL_STATUS_REQUEST,INCOME_PROVING_FINANCIAL_STATUS_RESPONSE&page=2&size=1";
+        response = restTemplate.getForObject(url, String.class);
+        assertThat(response).isEqualTo("[ ]");
+    }
+
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryResourceTest.java
@@ -14,6 +14,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import uk.gov.digital.ho.pttg.api.AuditHistoryResource;
 import uk.gov.digital.ho.pttg.api.AuditRecord;
 import uk.gov.digital.ho.pttg.api.RequestData;
@@ -47,6 +49,7 @@ public class AuditHistoryResourceTest {
             ImmutableMap.of("some key", "some value"),
             "some nino"
     );
+    private static final Pageable SOME_PAGEABLE = PageRequest.of(5, 8);
 
     @Before
     public void setUp() {
@@ -60,20 +63,21 @@ public class AuditHistoryResourceTest {
     @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
     public void retrieveAuditHistory_callsAuditHistoryService() {
         List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
-        when(mockHistoryService.getAuditHistory(LocalDate.now(), eventTypes)).thenReturn(Arrays.asList(AUDIT_RECORD));
 
-        historyResource.retrieveAuditHistory(LocalDate.now(), eventTypes);
+        when(mockHistoryService.getAuditHistory(LocalDate.now(), eventTypes, SOME_PAGEABLE)).thenReturn(Arrays.asList(AUDIT_RECORD));
 
-        verify(mockHistoryService).getAuditHistory(LocalDate.now(), eventTypes);
+        historyResource.retrieveAuditHistory(LocalDate.now(), eventTypes, SOME_PAGEABLE);
+
+        verify(mockHistoryService).getAuditHistory(LocalDate.now(), eventTypes, SOME_PAGEABLE);
     }
 
     @Test
     public void retrieveAuditHistory_returnsResultFromAuditHistoryService() {
         List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
         List<AuditRecord> expected = Arrays.asList(AUDIT_RECORD);
-        when(mockHistoryService.getAuditHistory(LocalDate.now(), eventTypes)).thenReturn(expected);
+        when(mockHistoryService.getAuditHistory(LocalDate.now(), eventTypes, SOME_PAGEABLE)).thenReturn(expected);
 
-        List<AuditRecord> result = historyResource.retrieveAuditHistory(LocalDate.now(), eventTypes);
+        List<AuditRecord> result = historyResource.retrieveAuditHistory(LocalDate.now(), eventTypes, SOME_PAGEABLE);
 
         assertThat(result).isEqualTo(expected);
     }
@@ -81,28 +85,29 @@ public class AuditHistoryResourceTest {
     @Test
     public void retrieveAuditHistory_logsRequestParameters() {
         List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
-        when(mockHistoryService.getAuditHistory(LocalDate.now(), eventTypes)).thenReturn(Arrays.asList(AUDIT_RECORD));
+        when(mockHistoryService.getAuditHistory(LocalDate.now(), eventTypes, SOME_PAGEABLE)).thenReturn(Arrays.asList(AUDIT_RECORD));
 
-        historyResource.retrieveAuditHistory(LocalDate.now(), eventTypes);
+        historyResource.retrieveAuditHistory(LocalDate.now(), eventTypes, SOME_PAGEABLE);
 
         verify(mockAppender).doAppend(argThat(argument -> {
             LoggingEvent loggingEvent = (LoggingEvent) argument;
 
-            String expectedLogMessage = String.format("Requested Audit History for events [%s, %s] up to end date %s",
+            String expectedLogMessage = String.format("Requested Audit History for events [%s, %s] up to end date %s with pageable of %s",
                     INCOME_PROVING_FINANCIAL_STATUS_REQUEST.name(),
                     INCOME_PROVING_FINANCIAL_STATUS_RESPONSE.name(),
-                    LocalDate.now().format(DateTimeFormatter.ofPattern("yyy-MM-dd")));
+                    LocalDate.now().format(DateTimeFormatter.ofPattern("yyy-MM-dd")),
+                    SOME_PAGEABLE);
             return loggingEvent.getFormattedMessage().equals(expectedLogMessage) &&
-                    ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[2]).getFieldName().equals("event_id");
+                    ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[3]).getFieldName().equals("event_id");
         }));
     }
 
     @Test
     public void retrieveAuditHistory_logsResult() {
         List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
-        when(mockHistoryService.getAuditHistory(LocalDate.now(), eventTypes)).thenReturn(Arrays.asList(AUDIT_RECORD));
+        when(mockHistoryService.getAuditHistory(LocalDate.now(), eventTypes, SOME_PAGEABLE)).thenReturn(Arrays.asList(AUDIT_RECORD));
 
-        historyResource.retrieveAuditHistory(LocalDate.now(), eventTypes);
+        historyResource.retrieveAuditHistory(LocalDate.now(), eventTypes, SOME_PAGEABLE);
 
         verify(mockAppender).doAppend(argThat(argument -> {
             LoggingEvent loggingEvent = (LoggingEvent) argument;
@@ -113,6 +118,53 @@ public class AuditHistoryResourceTest {
         }));
     }
 
+    @Test
+    public void retrieveAuditHistory_nullPageable_useUnpaged() {
+        List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
 
+        historyResource.retrieveAuditHistory(LocalDate.now(), eventTypes, null);
 
+        verify(mockHistoryService).getAuditHistory(LocalDate.now(), eventTypes, Pageable.unpaged());
+    }
+
+    @Test
+    public void retrieveAuditHistory_nullPageable_logUnpaged() {
+        List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
+
+        historyResource.retrieveAuditHistory(LocalDate.now(), eventTypes, null);
+
+        verify(mockAppender).doAppend(argThat(argument -> {
+            LoggingEvent loggingEvent = (LoggingEvent) argument;
+
+            String expectedLogMessage = String.format("Requested Audit History for events [%s, %s] up to end date %s with pageable of %s",
+                    INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE, LocalDate.now(), null);
+            return loggingEvent.getFormattedMessage().equals(expectedLogMessage) &&
+                    ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[3]).getFieldName().equals("event_id");
+        }));
+    }
+
+    @Test
+    public void retrieveAuditHistory_nullToDate_useToday() {
+        List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
+
+        historyResource.retrieveAuditHistory(null, eventTypes, SOME_PAGEABLE);
+
+        verify(mockHistoryService).getAuditHistory(LocalDate.now(), eventTypes, SOME_PAGEABLE);
+    }
+
+    @Test
+    public void retrieveAuditHistory_nullToDate_logNull() {
+        List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
+
+        historyResource.retrieveAuditHistory(null, eventTypes, SOME_PAGEABLE);
+
+        verify(mockAppender).doAppend(argThat(argument -> {
+            LoggingEvent loggingEvent = (LoggingEvent) argument;
+
+            String expectedLogMessage = String.format("Requested Audit History for events [%s, %s] up to end date %s with pageable of %s",
+                    INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE, null, SOME_PAGEABLE);
+            return loggingEvent.getFormattedMessage().equals(expectedLogMessage) &&
+                    ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[3]).getFieldName().equals("event_id");
+        }));
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryResourceTest.java
@@ -119,31 +119,6 @@ public class AuditHistoryResourceTest {
     }
 
     @Test
-    public void retrieveAuditHistory_nullPageable_useUnpaged() {
-        List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
-
-        historyResource.retrieveAuditHistory(LocalDate.now(), eventTypes, null);
-
-        verify(mockHistoryService).getAuditHistory(LocalDate.now(), eventTypes, Pageable.unpaged());
-    }
-
-    @Test
-    public void retrieveAuditHistory_nullPageable_logUnpaged() {
-        List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
-
-        historyResource.retrieveAuditHistory(LocalDate.now(), eventTypes, null);
-
-        verify(mockAppender).doAppend(argThat(argument -> {
-            LoggingEvent loggingEvent = (LoggingEvent) argument;
-
-            String expectedLogMessage = String.format("Requested Audit History for events [%s, %s] up to end date %s with pageable of %s",
-                    INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE, LocalDate.now(), null);
-            return loggingEvent.getFormattedMessage().equals(expectedLogMessage) &&
-                    ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[3]).getFieldName().equals("event_id");
-        }));
-    }
-
-    @Test
     public void retrieveAuditHistory_nullToDate_useToday() {
         List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
 

--- a/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryResourceTest.java
@@ -32,6 +32,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.digital.ho.pttg.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_REQUEST;
 import static uk.gov.digital.ho.pttg.AuditEventType.INCOME_PROVING_FINANCIAL_STATUS_RESPONSE;
+import static uk.gov.digital.ho.pttg.application.LogEvent.PTTG_AUDIT_HISTORY_REQUEST_RECEIVED;
+import static uk.gov.digital.ho.pttg.application.LogEvent.PTTG_AUDIT_HISTORY_RESPONSE_SUCCESS;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AuditHistoryResourceTest {
@@ -98,7 +100,7 @@ public class AuditHistoryResourceTest {
                     LocalDate.now().format(DateTimeFormatter.ofPattern("yyy-MM-dd")),
                     SOME_PAGEABLE);
             return loggingEvent.getFormattedMessage().equals(expectedLogMessage) &&
-                    ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[3]).getFieldName().equals("event_id");
+                    loggingEvent.getArgumentArray()[3].equals(new ObjectAppendingMarker("event_id", PTTG_AUDIT_HISTORY_REQUEST_RECEIVED));
         }));
     }
 
@@ -113,7 +115,7 @@ public class AuditHistoryResourceTest {
             LoggingEvent loggingEvent = (LoggingEvent) argument;
 
             return loggingEvent.getFormattedMessage().equals("Returned 1 audit record(s) for history request") &&
-                    ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[1]).getFieldName().equals("event_id") &&
+                    loggingEvent.getArgumentArray()[1].equals(new ObjectAppendingMarker("event_id", PTTG_AUDIT_HISTORY_RESPONSE_SUCCESS)) &&
                     ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[2]).getFieldName().equals("request_duration_ms");
         }));
     }
@@ -139,7 +141,7 @@ public class AuditHistoryResourceTest {
             String expectedLogMessage = String.format("Requested Audit History for events [%s, %s] up to end date %s with pageable of %s",
                     INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE, null, SOME_PAGEABLE);
             return loggingEvent.getFormattedMessage().equals(expectedLogMessage) &&
-                    ((ObjectAppendingMarker) loggingEvent.getArgumentArray()[3]).getFieldName().equals("event_id");
+                    loggingEvent.getArgumentArray()[3].equals(new ObjectAppendingMarker("event_id", PTTG_AUDIT_HISTORY_REQUEST_RECEIVED));
         }));
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import uk.gov.digital.ho.pttg.api.AuditRecord;
 
@@ -31,25 +32,28 @@ public class AuditHistoryServiceTest {
     @Test
     public void getAuditHistory_callsAuditRepo() {
         List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST);
-        auditHistoryService.getAuditHistory(LocalDate.now(), eventTypes);
+        Pageable pageable = PageRequest.of(3, 5);
+        auditHistoryService.getAuditHistory(LocalDate.now(), eventTypes, pageable);
 
-        verify(repository).findAuditHistory(any(LocalDateTime.class), eq(eventTypes), eq(Pageable.unpaged()));
+        verify(repository).findAuditHistory(any(LocalDateTime.class), eq(eventTypes), eq(pageable));
     }
 
     @Test
     public void getAuditHistory_queriesWithEndOfDay() {
         List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST);
-        auditHistoryService.getAuditHistory(LocalDate.now(), eventTypes);
+        Pageable somePageable = Pageable.unpaged();
+        auditHistoryService.getAuditHistory(LocalDate.now(), eventTypes, somePageable);
 
-        verify(repository).findAuditHistory(LocalDateTime.now().withHour(23).withMinute(59).withSecond(59).withNano(999), eventTypes, Pageable.unpaged());
+        verify(repository).findAuditHistory(LocalDateTime.now().withHour(23).withMinute(59).withSecond(59).withNano(999), eventTypes, somePageable);
     }
 
     @Test
     public void getAuditHistory_returnsAuditRecords() {
         List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST);
-        when(repository.findAuditHistory(any(LocalDateTime.class), anyList(), eq(Pageable.unpaged()))).thenReturn(Arrays.asList(getAuditEntry()));
+        Pageable somePageable = Pageable.unpaged();
+        when(repository.findAuditHistory(any(LocalDateTime.class), anyList(), eq(somePageable))).thenReturn(Arrays.asList(getAuditEntry()));
 
-        List<AuditRecord> auditRecords = auditHistoryService.getAuditHistory(LocalDate.now(), eventTypes);
+        List<AuditRecord> auditRecords = auditHistoryService.getAuditHistory(LocalDate.now(), eventTypes, somePageable);
 
         assertThat(auditRecords).size().isEqualTo(1);
         AuditRecord auditRecord = auditRecords.get(0);

--- a/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.domain.Pageable;
 import uk.gov.digital.ho.pttg.api.AuditRecord;
 
 import java.time.LocalDate;
@@ -32,7 +33,7 @@ public class AuditHistoryServiceTest {
         List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST);
         auditHistoryService.getAuditHistory(LocalDate.now(), eventTypes);
 
-        verify(repository).findAuditHistory(any(LocalDateTime.class), eq(eventTypes));
+        verify(repository).findAuditHistory(any(LocalDateTime.class), eq(eventTypes), eq(Pageable.unpaged()));
     }
 
     @Test
@@ -40,13 +41,13 @@ public class AuditHistoryServiceTest {
         List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST);
         auditHistoryService.getAuditHistory(LocalDate.now(), eventTypes);
 
-        verify(repository).findAuditHistory(LocalDateTime.now().withHour(23).withMinute(59).withSecond(59).withNano(999), eventTypes);
+        verify(repository).findAuditHistory(LocalDateTime.now().withHour(23).withMinute(59).withSecond(59).withNano(999), eventTypes, Pageable.unpaged());
     }
 
     @Test
     public void getAuditHistory_returnsAuditRecords() {
         List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST);
-        when(repository.findAuditHistory(any(LocalDateTime.class), anyList())).thenReturn(Arrays.asList(getAuditEntry()));
+        when(repository.findAuditHistory(any(LocalDateTime.class), anyList(), eq(Pageable.unpaged()))).thenReturn(Arrays.asList(getAuditEntry()));
 
         List<AuditRecord> auditRecords = auditHistoryService.getAuditHistory(LocalDate.now(), eventTypes);
 

--- a/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryWebTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryWebTest.java
@@ -1,11 +1,11 @@
 package uk.gov.digital.ho.pttg;
 
-import org.apache.http.entity.ContentType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.digital.ho.pttg.api.AuditHistoryResource;
@@ -56,7 +56,7 @@ public class AuditHistoryWebTest {
                     .param("eventTypes", EVENT_TYPES_PARAM)
                 );
 
-        verify(mockAuditHistoryService).getAuditHistory(REQ_DATE, EVENT_TYPES);
+        verify(mockAuditHistoryService).getAuditHistory(REQ_DATE, EVENT_TYPES, Pageable.unpaged());
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryWebTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/AuditHistoryWebTest.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
@@ -56,7 +57,8 @@ public class AuditHistoryWebTest {
                     .param("eventTypes", EVENT_TYPES_PARAM)
                 );
 
-        verify(mockAuditHistoryService).getAuditHistory(REQ_DATE, EVENT_TYPES, Pageable.unpaged());
+        Pageable defaultPageable = PageRequest.of(0, 20);
+        verify(mockAuditHistoryService).getAuditHistory(REQ_DATE, EVENT_TYPES, defaultPageable);
     }
 
     @Test


### PR DESCRIPTION
Made it so that the request to get audit data is paginated. This is so that ip-api can retrieve all the audit data in a controlled fashion. As this is an endpoint change, I will request a manual test before merging it into master: EE-17214