### PR TITLE
Ee 19133 all correlation ids

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepository.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepository.java
@@ -40,7 +40,8 @@ public interface AuditEntryJpaRepository extends PagingAndSortingRepository<Audi
     @Query("SELECT audit from AuditEntry audit WHERE audit.timestamp >= :fromDate AND audit.timestamp < :toDate AND audit.type = 'ARCHIVED_RESULTS'")
     List<AuditEntry> findArchivedResults(@Param("fromDate") LocalDateTime fromDate, @Param("toDate") LocalDateTime toDate);
 
-
+    @Query("SELECT DISTINCT(audit.correlationId) from AuditEntry audit WHERE audit.type in (:eventTypes)")
+    List<String> getAllCorrelationIds(@Param("eventTypes") List<AuditEventType> eventTypes);
 
 }
 

--- a/src/test/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepositoryStubCountNinosAfterDate.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepositoryStubCountNinosAfterDate.java
@@ -77,6 +77,11 @@ class AuditEntryJpaRepositoryStubCountNinosAfterDate implements AuditEntryJpaRep
     }
 
     @Override
+    public List<String> getAllCorrelationIds(List<AuditEventType> eventTypes) {
+        return realRepository.getAllCorrelationIds(eventTypes);
+    }
+
+    @Override
     @Modifying
     @Transactional
     public void deleteAllCorrelationIds(List<String> correlationIds) {

--- a/src/test/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepositoryTest.java
@@ -280,7 +280,7 @@ public class AuditEntryJpaRepositoryTest {
     @Test
     public void getAllCorrelationIds_givenEventType_returnCorrelationIds() {
         String correlationId = "some correlation id";
-        repository.save(createAuditWithCorrelationId(NOW, USER_ID, correlationId));
+        repository.save(createAudit(correlationId, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE));
 
         List<String> correlationIds = repository.getAllCorrelationIds(singletonList(INCOME_PROVING_FINANCIAL_STATUS_RESPONSE));
         assertThat(correlationIds)
@@ -288,13 +288,13 @@ public class AuditEntryJpaRepositoryTest {
     }
 
     @Test
-    public void getAllCorrelationIds_givenEventTypes_returnOnlyCorrelationIdsForEventTypes() {
+    public void getAllCorrelationIds_givenEventType_returnOnlyCorrelationIdsForEventType() {
         String correlationId1 = "some correlation id";
         String correlationId2 = "some other correlation id";
         String correlationId3 = "yet some other correlation id";
-        repository.save(createAudit(NOW, USER_ID, correlationId1, INCOME_PROVING_INCOME_CHECK_REQUEST));
-        repository.save(createAudit(NOW, USER_ID, correlationId2, INCOME_PROVING_INCOME_CHECK_REQUEST));
-        repository.save(createAudit(NOW, USER_ID, correlationId3, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE));
+        repository.save(createAudit(correlationId1, INCOME_PROVING_INCOME_CHECK_REQUEST));
+        repository.save(createAudit(correlationId2, INCOME_PROVING_INCOME_CHECK_REQUEST));
+        repository.save(createAudit(correlationId3, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE));
 
         List<String> correlationIds = repository.getAllCorrelationIds(singletonList(INCOME_PROVING_INCOME_CHECK_REQUEST));
         assertThat(correlationIds)
@@ -302,10 +302,24 @@ public class AuditEntryJpaRepositoryTest {
     }
 
     @Test
+    public void getAllCorrelationIds_multipleEventTypes_returnCorrelationIdsForEventTypes() {
+        String correlationId1 = "some correlation id";
+        String correlationId2 = "some other correlation id";
+        String correlationId3 = "yet some other correlation id";
+        repository.save(createAudit(correlationId1, INCOME_PROVING_INCOME_CHECK_REQUEST));
+        repository.save(createAudit(correlationId2, DWP_BENEFIT_REQUEST));
+        repository.save(createAudit(correlationId3, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE));
+
+        List<String> correlationIds = repository.getAllCorrelationIds(Arrays.asList(INCOME_PROVING_INCOME_CHECK_REQUEST, DWP_BENEFIT_REQUEST));
+        assertThat(correlationIds)
+                .contains(correlationId1, correlationId2);
+    }
+
+    @Test
     public void getAllCorrelationIds_multipleEntriesPerCorrelationId_returnDistinctIds() {
         String correlationId = "some correlation id";
-        repository.save(createAudit(NOW, USER_ID, correlationId, INCOME_PROVING_INCOME_CHECK_REQUEST));
-        repository.save(createAudit(NOW, USER_ID, correlationId, INCOME_PROVING_INCOME_CHECK_REQUEST));
+        repository.save(createAudit(correlationId, INCOME_PROVING_INCOME_CHECK_REQUEST));
+        repository.save(createAudit(correlationId, INCOME_PROVING_INCOME_CHECK_REQUEST));
 
         assertThat(repository.getAllCorrelationIds(singletonList(INCOME_PROVING_INCOME_CHECK_REQUEST)))
                 .hasSize(1)
@@ -320,13 +334,13 @@ public class AuditEntryJpaRepositoryTest {
         return createAudit(timestamp, userId, DETAIL);
     }
 
-    private AuditEntry createAudit(LocalDateTime timestamp, String userId, String correlationId, AuditEventType eventType) {
+    private AuditEntry createAudit(String correlationId, AuditEventType eventType) {
         return new AuditEntry(
                 randomUUID().toString(),
-                timestamp,
+                NOW,
                 SESSION_ID,
                 correlationId,
-                userId,
+                USER_ID,
                 DEPLOYMENT,
                 NAMESPACE,
                 eventType,

--- a/src/test/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepositoryTest.java
@@ -298,7 +298,7 @@ public class AuditEntryJpaRepositoryTest {
 
         List<String> correlationIds = repository.getAllCorrelationIds(singletonList(INCOME_PROVING_INCOME_CHECK_REQUEST));
         assertThat(correlationIds)
-                .contains(correlationId1, correlationId2);
+                .containsOnly(correlationId1, correlationId2);
     }
 
     @Test
@@ -312,16 +312,16 @@ public class AuditEntryJpaRepositoryTest {
 
         List<String> correlationIds = repository.getAllCorrelationIds(Arrays.asList(INCOME_PROVING_INCOME_CHECK_REQUEST, DWP_BENEFIT_REQUEST));
         assertThat(correlationIds)
-                .contains(correlationId1, correlationId2);
+                .containsOnly(correlationId1, correlationId2);
     }
 
     @Test
     public void getAllCorrelationIds_multipleEntriesPerCorrelationId_returnDistinctIds() {
         String correlationId = "some correlation id";
         repository.save(createAudit(correlationId, INCOME_PROVING_INCOME_CHECK_REQUEST));
-        repository.save(createAudit(correlationId, INCOME_PROVING_INCOME_CHECK_REQUEST));
+        repository.save(createAudit(correlationId, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE));
 
-        assertThat(repository.getAllCorrelationIds(singletonList(INCOME_PROVING_INCOME_CHECK_REQUEST)))
+        assertThat(repository.getAllCorrelationIds(Arrays.asList(INCOME_PROVING_INCOME_CHECK_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE)))
                 .hasSize(1)
                 .contains(correlationId);
     }

--- a/src/test/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepositoryTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepositoryTest.java
@@ -319,9 +319,9 @@ public class AuditEntryJpaRepositoryTest {
     public void getAllCorrelationIds_multipleEntriesPerCorrelationId_returnDistinctIds() {
         String correlationId = "some correlation id";
         repository.save(createAudit(correlationId, INCOME_PROVING_INCOME_CHECK_REQUEST));
-        repository.save(createAudit(correlationId, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE));
+        repository.save(createAudit(correlationId, DWP_BENEFIT_REQUEST));
 
-        assertThat(repository.getAllCorrelationIds(Arrays.asList(INCOME_PROVING_INCOME_CHECK_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE)))
+        assertThat(repository.getAllCorrelationIds(Arrays.asList(INCOME_PROVING_INCOME_CHECK_REQUEST, DWP_BENEFIT_REQUEST)))
                 .hasSize(1)
                 .contains(correlationId);
     }


### PR DESCRIPTION
Added in a database query to get all the distinct correlation IDs for a given list of Audit Event Types. Can merge straight to master as it is not wired up to anything.