### PR TITLE
EE-21001 Get all correlationIDs with a toDate

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepository.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepository.java
@@ -43,6 +43,9 @@ public interface AuditEntryJpaRepository extends PagingAndSortingRepository<Audi
     @Query("SELECT DISTINCT(audit.correlationId) from AuditEntry audit WHERE audit.type in (:eventTypes)")
     List<String> getAllCorrelationIds(@Param("eventTypes") List<AuditEventType> eventTypes);
 
+    @Query("SELECT DISTINCT(audit.correlationId) FROM AuditEntry audit WHERE audit.type in (:eventTypes) AND audit.timestamp <= :toDate")
+    List<String> getAllCorrelationIds(@Param("eventTypes") List<AuditEventType> eventTypes, @Param("toDate") LocalDateTime toDate);
+
     @Query("SELECT audit from AuditEntry audit WHERE audit.correlationId = :correlationId AND audit.type in (:eventTypes)")
     List<AuditEntry> findEntriesByCorrelationId(@Param("correlationId") String correlationId, @Param("eventTypes") List<AuditEventType> eventTypes);
 

--- a/src/test/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepositoryStubCountNinosAfterDate.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/AuditEntryJpaRepositoryStubCountNinosAfterDate.java
@@ -82,6 +82,11 @@ class AuditEntryJpaRepositoryStubCountNinosAfterDate implements AuditEntryJpaRep
     }
 
     @Override
+    public List<String> getAllCorrelationIds(List<AuditEventType> eventTypes, LocalDateTime toDate) {
+        return realRepository.getAllCorrelationIds(eventTypes, toDate);
+    }
+
+    @Override
     @Modifying
     @Transactional
     public void deleteAllCorrelationIds(List<String> correlationIds) {


### PR DESCRIPTION
Added a new query to the repository to get all correlation IDs for a given Audit Event Type but with a toDate. This is so that when calculating pass rate statistics with a cut off date, we don't need to get all the data.

I will merge once approved as the code isn't connected to anything.