### PR TITLE
Ee 21001 AuditHistoryService methods and AuditHistoryResourceTest Refactor

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/AuditHistoryService.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/AuditHistoryService.java
@@ -6,6 +6,7 @@ import uk.gov.digital.ho.pttg.api.AuditRecord;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,6 +29,11 @@ public class AuditHistoryService {
 
     public List<String> getAllCorrelationIds(List<AuditEventType> eventTypes){
         return repository.getAllCorrelationIds(eventTypes);
+    }
+
+    public List<String> getAllCorrelationIds(List<AuditEventType> eventTypes, LocalDate toDate) {
+        LocalDateTime endOfToDate = toDate.atTime(LocalTime.MAX);
+        return repository.getAllCorrelationIds(eventTypes, endOfToDate);
     }
 
     public List<AuditRecord> getRecordsForCorrelationId(String correlationId, List<AuditEventType> eventTypes) {

--- a/src/test/java/uk/gov/digital/ho/pttg/api/AuditHistoryResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/AuditHistoryResourceTest.java
@@ -59,6 +59,7 @@ public class AuditHistoryResourceTest {
             "some nino"
     );
     private static final Pageable SOME_PAGEABLE = PageRequest.of(5, 8);
+    private static final List<AuditEventType> ANY_EVENT_TYPES = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
 
     @Before
     public void setUp() {
@@ -164,8 +165,7 @@ public class AuditHistoryResourceTest {
         when(mockHistoryService.getAllCorrelationIds(any()))
                 .thenReturn(correlationIds);
 
-        List<AuditEventType> anyEventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
-        List<String> returnedCorrelationIds = historyResource.getAllCorrelationIds(anyEventTypes);
+        List<String> returnedCorrelationIds = historyResource.getAllCorrelationIds(ANY_EVENT_TYPES);
 
         assertThat(returnedCorrelationIds).isEqualTo(correlationIds);
     }
@@ -190,8 +190,7 @@ public class AuditHistoryResourceTest {
         List<String> correlationIds = Arrays.asList("some correlation id", "some other correlation id", "yet some other correlation id");
         given(mockHistoryService.getAllCorrelationIds(any())).willReturn(correlationIds);
 
-        List<AuditEventType> anyEventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
-        historyResource.getAllCorrelationIds(anyEventTypes);
+        historyResource.getAllCorrelationIds(ANY_EVENT_TYPES);
 
         then(mockAppender).should(atLeastOnce()).doAppend(logCaptor.capture());
 
@@ -217,8 +216,7 @@ public class AuditHistoryResourceTest {
         when(mockHistoryService.getRecordsForCorrelationId(any(), any()))
                 .thenReturn(expectedRecords);
 
-        List<AuditEventType> anyEventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
-        List<AuditRecord> actualRecords = historyResource.getRecordsForCorrelationId("any correlation ID", anyEventTypes);
+        List<AuditRecord> actualRecords = historyResource.getRecordsForCorrelationId("any correlation ID", ANY_EVENT_TYPES);
 
         assertThat(actualRecords).isEqualTo(expectedRecords);
     }

--- a/src/test/java/uk/gov/digital/ho/pttg/api/AuditHistoryResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/AuditHistoryResourceTest.java
@@ -123,7 +123,7 @@ public class AuditHistoryResourceTest {
 
         LoggingEvent loggingEvent = logForEvent(PTTG_AUDIT_HISTORY_RESPONSE_SUCCESS);
         assertThat(loggingEvent.getFormattedMessage()).isEqualTo("Returned 1 audit record(s) for history request");
-        assertThat(((ObjectAppendingMarker) loggingEvent.getArgumentArray()[2]).getFieldName()).isEqualTo("request_duration_ms");
+        assertRequestDurationLogged(loggingEvent);
     }
 
     @Test
@@ -198,7 +198,7 @@ public class AuditHistoryResourceTest {
         String expectedMessage = "Returning 3 correlation IDs for all correlation ID request";
         LoggingEvent loggingEvent = logForEvent(PTTG_AUDIT_HISTORY_CORRELATION_IDS_RESPONSE_SUCCESS);
         assertThat(loggingEvent.getFormattedMessage()).isEqualTo(expectedMessage);
-        assertThat(((ObjectAppendingMarker) loggingEvent.getArgumentArray()[2]).getFieldName()).isEqualTo("request_duration_ms");
+        assertRequestDurationLogged(loggingEvent);
     }
 
     @Test
@@ -259,7 +259,7 @@ public class AuditHistoryResourceTest {
         String expectedMessage = "Returned 3 audit records for correlation ID some-correlation-ID";
         LoggingEvent loggingEvent = logForEvent(PTTG_AUDIT_HISTORY_BY_CORRELATION_ID_RESPONSE_SUCCESS);
         assertThat(loggingEvent.getFormattedMessage()).isEqualTo(expectedMessage);
-        assertThat(((ObjectAppendingMarker) loggingEvent.getArgumentArray()[3]).getFieldName()).isEqualTo("request_duration_ms");
+        assertRequestDurationLogged(loggingEvent);
     }
 
     private LoggingEvent logForEvent(LogEvent logEvent) {
@@ -267,5 +267,15 @@ public class AuditHistoryResourceTest {
                         .filter(loggingEvent -> ArrayUtils.contains(loggingEvent.getArgumentArray(), new ObjectAppendingMarker("event_id", logEvent)))
                         .findFirst()
                         .orElseThrow(AssertionError::new);
+    }
+
+    private void assertRequestDurationLogged(LoggingEvent loggingEvent) {
+        boolean hasRequestDuration = Arrays.stream(loggingEvent.getArgumentArray()).anyMatch(AuditHistoryResourceTest::isRequestDuration);
+        assertThat(hasRequestDuration).isTrue();
+    }
+
+    private static boolean isRequestDuration(Object logArg) {
+        return logArg instanceof ObjectAppendingMarker &&
+                ((ObjectAppendingMarker) logArg).getFieldName().equals("request_duration_ms");
     }
 }


### PR DESCRIPTION
Added an overload of getAllCorrelationIds to the AuditHistoryService which takes a LocalDate and returns all correlation IDs for events up to that date.

The next step will be to change the AuditHistoryResource so that correlation IDs can be requested up to a given date. This will require me to write more tests in AuditHistoryResourceTest. In order to make this easier, I have refactored this test class so that it is clearer, the tests are less brittle, and there are more useful utility methods.

As nothing externally observable has been changed I intend to merge once approved.