### PR TITLE
Ee 21001 get correlation ids end month resource with toDate

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/api/AuditHistoryResource.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/AuditHistoryResource.java
@@ -67,6 +67,18 @@ public class AuditHistoryResource {
         return correlationIds;
     }
 
+    public List<String> getAllCorrelationIds(List<AuditEventType> eventTypes, LocalDate toDate) {
+        log.info("Requested all correlation ids for events {} up to {}", eventTypes, toDate, value(EVENT, PTTG_AUDIT_HISTORY_CORRELATION_IDS_REQUEST_RECEIVED));
+
+        List<String> correlationIds = auditHistoryService.getAllCorrelationIds(eventTypes, toDate);
+
+        log.info("Returning {} correlation IDs for all correlation ID request", correlationIds.size(),
+                 value(EVENT, PTTG_AUDIT_HISTORY_CORRELATION_IDS_RESPONSE_SUCCESS),
+                 value(REQUEST_DURATION_MS, requestData.calculateRequestDuration()));
+
+        return correlationIds;
+    }
+
     @GetMapping(value = "/historyByCorrelationId", produces = APPLICATION_JSON_VALUE)
     public List<AuditRecord> getRecordsForCorrelationId(
             @RequestParam String correlationId, @RequestParam List<AuditEventType> eventTypes) {

--- a/src/main/java/uk/gov/digital/ho/pttg/api/AuditHistoryResource.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/AuditHistoryResource.java
@@ -55,27 +55,12 @@ public class AuditHistoryResource {
     }
 
     @GetMapping(value = "/correlationIds", produces = APPLICATION_JSON_VALUE)
-    public List<String> getAllCorrelationIds(@RequestParam List<AuditEventType> eventTypes) {
-        log.info("Requested all correlation ids for events {}", eventTypes, value(EVENT, PTTG_AUDIT_HISTORY_CORRELATION_IDS_REQUEST_RECEIVED));
+    public List<String> getAllCorrelationIds(@RequestParam List<AuditEventType> eventTypes,
+                                             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate) {
 
-        List<String> correlationIds = auditHistoryService.getAllCorrelationIds(eventTypes);
-
-        log.info("Returning {} correlation IDs for all correlation ID request", correlationIds.size(),
-                value(EVENT, PTTG_AUDIT_HISTORY_CORRELATION_IDS_RESPONSE_SUCCESS),
-                value(REQUEST_DURATION_MS, requestData.calculateRequestDuration()));
-
-        return correlationIds;
-    }
-
-    public List<String> getAllCorrelationIds(List<AuditEventType> eventTypes, LocalDate toDate) {
-        log.info("Requested all correlation ids for events {} up to {}", eventTypes, toDate, value(EVENT, PTTG_AUDIT_HISTORY_CORRELATION_IDS_REQUEST_RECEIVED));
-
-        List<String> correlationIds = auditHistoryService.getAllCorrelationIds(eventTypes, toDate);
-
-        log.info("Returning {} correlation IDs for all correlation ID request", correlationIds.size(),
-                 value(EVENT, PTTG_AUDIT_HISTORY_CORRELATION_IDS_RESPONSE_SUCCESS),
-                 value(REQUEST_DURATION_MS, requestData.calculateRequestDuration()));
-
+        logGetAllCorrelationIdEntry(eventTypes, toDate);
+        List<String> correlationIds = getCorrelationIdsFromService(eventTypes, toDate);
+        logCorrelationIdCount(correlationIds);
         return correlationIds;
     }
 
@@ -93,6 +78,27 @@ public class AuditHistoryResource {
                 value(REQUEST_DURATION_MS, requestData.calculateRequestDuration()));
 
         return records;
+    }
+
+    private void logGetAllCorrelationIdEntry(List<AuditEventType> eventTypes, LocalDate toDate) {
+        if (toDate == null) {
+            log.info("Requested all correlation ids for events {}", eventTypes, value(EVENT, PTTG_AUDIT_HISTORY_CORRELATION_IDS_REQUEST_RECEIVED));
+        } else {
+            log.info("Requested all correlation ids for events {} up to {}", eventTypes, toDate, value(EVENT, PTTG_AUDIT_HISTORY_CORRELATION_IDS_REQUEST_RECEIVED));
+        }
+    }
+
+    private List<String> getCorrelationIdsFromService(List<AuditEventType> eventTypes, LocalDate toDate) {
+        if (toDate == null) {
+            return auditHistoryService.getAllCorrelationIds(eventTypes);
+        }
+        return auditHistoryService.getAllCorrelationIds(eventTypes, toDate);
+    }
+
+    private void logCorrelationIdCount(List<String> correlationIds) {
+        log.info("Returning {} correlation IDs for all correlation ID request", correlationIds.size(),
+                 value(EVENT, PTTG_AUDIT_HISTORY_CORRELATION_IDS_RESPONSE_SUCCESS),
+                 value(REQUEST_DURATION_MS, requestData.calculateRequestDuration()));
     }
 
     private LocalDate useDefaultIfNull(LocalDate toDate) {

--- a/src/test/java/uk/gov/digital/ho/pttg/api/AuditHistoryResourceCorrelationIdIntTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/AuditHistoryResourceCorrelationIdIntTest.java
@@ -38,7 +38,17 @@ public class AuditHistoryResourceCorrelationIdIntTest {
         String url = "/correlationIds?eventTypes=INCOME_PROVING_FINANCIAL_STATUS_REQUEST,INCOME_PROVING_FINANCIAL_STATUS_RESPONSE";
         String response = restTemplate.getForObject(url, String.class);
 
-        List<String> list = objectMapper.readValue(response, List.class);
-        assertThat(list).containsExactlyInAnyOrder("correlationID1", "correlationID3");
+        List<String> correlationIds = objectMapper.readValue(response, List.class);
+        assertThat(correlationIds).containsExactlyInAnyOrder("correlationID1", "correlationID3");
+    }
+
+    @Test
+    public void shouldReturnCorrelationIdsForRequesteEventTypesBeforeDate() throws IOException {
+        String url = "/correlationIds?eventTypes=INCOME_PROVING_FINANCIAL_STATUS_REQUEST,INCOME_PROVING_FINANCIAL_STATUS_RESPONSE";
+        url += "&toDate=2017-09-11";
+        String response = restTemplate.getForObject(url, String.class);
+
+        List<String> correlationIds = objectMapper.readValue(response, List.class);
+        assertThat(correlationIds).containsExactly("correlationID1");
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/api/AuditHistoryResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/AuditHistoryResourceTest.java
@@ -154,7 +154,7 @@ public class AuditHistoryResourceTest {
     public void getAllCorrelationIds_givenEventTypes_passToService() {
         List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
 
-        historyResource.getAllCorrelationIds(eventTypes);
+        historyResource.getAllCorrelationIds(eventTypes, null);
 
         verify(mockHistoryService).getAllCorrelationIds(eq(eventTypes));
     }
@@ -165,7 +165,7 @@ public class AuditHistoryResourceTest {
         when(mockHistoryService.getAllCorrelationIds(any()))
                 .thenReturn(correlationIds);
 
-        List<String> returnedCorrelationIds = historyResource.getAllCorrelationIds(ANY_EVENT_TYPES);
+        List<String> returnedCorrelationIds = historyResource.getAllCorrelationIds(ANY_EVENT_TYPES, null);
 
         assertThat(returnedCorrelationIds).isEqualTo(correlationIds);
     }
@@ -174,7 +174,7 @@ public class AuditHistoryResourceTest {
     public void getAllCorrelationIds_givenEventTypes_logEntryParameters() {
         List<AuditEventType> eventTypes = Arrays.asList(INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
 
-        historyResource.getAllCorrelationIds(eventTypes);
+        historyResource.getAllCorrelationIds(eventTypes, null);
 
         String expectedLogMessage = String.format("Requested all correlation ids for events [%s, %s]",
                 INCOME_PROVING_FINANCIAL_STATUS_REQUEST, INCOME_PROVING_FINANCIAL_STATUS_RESPONSE);
@@ -190,7 +190,7 @@ public class AuditHistoryResourceTest {
         List<String> correlationIds = Arrays.asList("some correlation id", "some other correlation id", "yet some other correlation id");
         given(mockHistoryService.getAllCorrelationIds(any())).willReturn(correlationIds);
 
-        historyResource.getAllCorrelationIds(ANY_EVENT_TYPES);
+        historyResource.getAllCorrelationIds(ANY_EVENT_TYPES, null);
 
         then(mockAppender).should(atLeastOnce()).doAppend(logCaptor.capture());
 

--- a/src/test/resources/sql/AuditHistoryCorrelationIdIntTest/before.sql
+++ b/src/test/resources/sql/AuditHistoryCorrelationIdIntTest/before.sql
@@ -32,7 +32,7 @@ INSERT INTO audit
     VALUES (
       '3',
       'yet some other uuid',
-      '2017-09-11 14:45:48.014',
+      '2017-09-12 14:45:48.014',
       'some session id',
       'correlationID3',
       'some email',


### PR DESCRIPTION
Added an optional toDate parameter to the /correlationIds endpoint so that correlation IDs can be retrieved up to a given date.

I've also tightened up some of the Web Tests for the /correlationIds endpoint so that they test for a 400 Bad Request HTTP Status code rather than any 4xx client error.


As this changes the behaviour of the audit-service I will not merge when approved. I will instead put the PR on the JIRA to be tested when the story is tested.