### PR TITLE
Ee 6825 component trace

### DIFF
--- a/src/main/java/uk/gov/digital/ho/pttg/api/RequestData.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/RequestData.java
@@ -20,6 +20,8 @@ public class RequestData implements HandlerInterceptor {
     static final String USER_HOST = "userHost";
     static final String REQUEST_START_TIMESTAMP = "request-timestamp";
     public static final String REQUEST_DURATION_MS = "request_duration_ms";
+    private static final String COMPONENT_TRACE_HEADER = "x-component-trace";
+    private static final String COMPONENT_NAME = "pttg-ip-audit";
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
@@ -31,7 +33,7 @@ public class RequestData implements HandlerInterceptor {
         MDC.put(USER_ID_HEADER, initialiseUserName(request));
         MDC.put(USER_HOST, initialiseRemoteHost(request));
         MDC.put(REQUEST_START_TIMESTAMP, initialiseRequestStart());
-        MDC.put("x-component-trace", initialiseComponentTraceHeader(request));
+        MDC.put(COMPONENT_TRACE_HEADER, initialiseComponentTraceHeader(request));
 
 
         response.setHeader(SESSION_ID_HEADER, sessionId());
@@ -72,11 +74,11 @@ public class RequestData implements HandlerInterceptor {
     }
 
     private String initialiseComponentTraceHeader(HttpServletRequest request) {
-        String componentTrace = request.getHeader("x-component-trace");
+        String componentTrace = request.getHeader(COMPONENT_TRACE_HEADER);
         if (componentTrace == null) {
-            return "pttg-ip-audit";
+            return COMPONENT_NAME;
         }
-        return componentTrace + "," + "pttg-ip-audit";
+        return componentTrace + "," + COMPONENT_NAME;
     }
 
     public String sessionId() {
@@ -97,6 +99,6 @@ public class RequestData implements HandlerInterceptor {
     }
 
     public String componentTrace() {
-        return MDC.get("x-component-trace");
+        return MDC.get(COMPONENT_TRACE_HEADER);
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/api/RequestData.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/RequestData.java
@@ -31,6 +31,7 @@ public class RequestData implements HandlerInterceptor {
         MDC.put(USER_ID_HEADER, initialiseUserName(request));
         MDC.put(USER_HOST, initialiseRemoteHost(request));
         MDC.put(REQUEST_START_TIMESTAMP, initialiseRequestStart());
+        MDC.put("x-component-trace", initialiseComponentTraceHeader(request));
 
 
         response.setHeader(SESSION_ID_HEADER, sessionId());
@@ -70,6 +71,14 @@ public class RequestData implements HandlerInterceptor {
         return StringUtils.isNotBlank(userId) ? userId : "anonymous";
     }
 
+    private String initialiseComponentTraceHeader(HttpServletRequest request) {
+        String componentTrace = request.getHeader("x-component-trace");
+        if (componentTrace == null) {
+            return "pttg-ip-audit";
+        }
+        return componentTrace + "," + "pttg-ip-audit";
+    }
+
     public String sessionId() {
         return MDC.get(SESSION_ID_HEADER);
     }
@@ -85,5 +94,9 @@ public class RequestData implements HandlerInterceptor {
     public long calculateRequestDuration() {
         long timeStamp = Instant.now().toEpochMilli();
         return timeStamp - Long.parseLong(MDC.get(REQUEST_START_TIMESTAMP));
+    }
+
+    public String componentTrace() {
+        return MDC.get("x-component-trace");
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/api/RequestData.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/RequestData.java
@@ -2,6 +2,7 @@ package uk.gov.digital.ho.pttg.api;
 
 import net.logstash.logback.encoder.org.apache.commons.lang.StringUtils;
 import org.slf4j.MDC;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.util.WebUtils;
@@ -20,7 +21,7 @@ public class RequestData implements HandlerInterceptor {
     static final String USER_HOST = "userHost";
     static final String REQUEST_START_TIMESTAMP = "request-timestamp";
     public static final String REQUEST_DURATION_MS = "request_duration_ms";
-    private static final String COMPONENT_TRACE_HEADER = "x-component-trace";
+    static final String COMPONENT_TRACE_HEADER = "x-component-trace";
     private static final String COMPONENT_NAME = "pttg-ip-audit";
 
     @Override
@@ -100,5 +101,9 @@ public class RequestData implements HandlerInterceptor {
 
     public String componentTrace() {
         return MDC.get(COMPONENT_TRACE_HEADER);
+    }
+
+    public void addComponentTraceHeader(HttpHeaders headers) {
+        headers.add(COMPONENT_TRACE_HEADER, componentTrace());
     }
 }

--- a/src/main/java/uk/gov/digital/ho/pttg/application/ComponentTraceControllerAdvice.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/application/ComponentTraceControllerAdvice.java
@@ -1,0 +1,28 @@
+package uk.gov.digital.ho.pttg.application;
+
+import lombok.AllArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+import uk.gov.digital.ho.pttg.api.RequestData;
+
+@ControllerAdvice
+@AllArgsConstructor
+public class ComponentTraceControllerAdvice implements ResponseBodyAdvice {
+
+    private final RequestData requestData;
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType, Class selectedConverterType, ServerHttpRequest request, ServerHttpResponse response) {
+        requestData.addComponentTraceHeader(response.getHeaders());
+        return body;
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/pttg/api/RequestDataTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/RequestDataTest.java
@@ -5,12 +5,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpHeaders;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,6 +29,8 @@ public class RequestDataTest {
     private HttpServletResponse mockResponse;
     @Mock
     private Object mockHandler;
+    @Mock
+    private HttpHeaders mockHeaders;
 
     @Test
     public void shouldUseCollaborators() {
@@ -119,5 +123,15 @@ public class RequestDataTest {
         requestData.preHandle(mockRequest, mockResponse, mockHandler);
 
         assertThat(requestData.componentTrace()).isEqualTo("pttg-ip-api,pttg-ip-hmrc,pttg-ip-audit");
+    }
+
+    @Test
+    public void addComponentTraceHeader_anyResponse_addsHeader() {
+        String expectedComponentTrace = "some-component,some-other-component";
+        org.slf4j.MDC.put(COMPONENT_TRACE_HEADER, expectedComponentTrace);
+
+        requestData.addComponentTraceHeader(mockHeaders);
+
+        then(mockHeaders).should().add(COMPONENT_TRACE_HEADER, expectedComponentTrace);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/pttg/application/ComponentTraceControllerAdviceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/ComponentTraceControllerAdviceTest.java
@@ -15,11 +15,12 @@ import uk.gov.digital.ho.pttg.api.RequestData;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ComponentTraceControllerAdviceTest {
 
-    private static final MethodParameter ANY_RETURN_TYPE = null;
+    private static final MethodParameter ANY_RETURN_TYPE = mock(MethodParameter.class);
     private static final Class ANY_CONVERTER_TYPE = ComponentTraceControllerAdvice.class;
     private static final MediaType ANY_MEDIA_TYPE = MediaType.APPLICATION_JSON;
 

--- a/src/test/java/uk/gov/digital/ho/pttg/application/ComponentTraceControllerAdviceTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/application/ComponentTraceControllerAdviceTest.java
@@ -1,0 +1,63 @@
+package uk.gov.digital.ho.pttg.application;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import uk.gov.digital.ho.pttg.api.RequestData;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ComponentTraceControllerAdviceTest {
+
+    private static final MethodParameter ANY_RETURN_TYPE = null;
+    private static final Class ANY_CONVERTER_TYPE = ComponentTraceControllerAdvice.class;
+    private static final MediaType ANY_MEDIA_TYPE = MediaType.APPLICATION_JSON;
+
+    @Mock
+    private ServerHttpRequest mockRequest;
+    @Mock
+    private ServerHttpResponse mockResponse;
+    @Mock
+    private RequestData mockRequestData;
+
+    private ComponentTraceControllerAdvice controllerAdvice;
+
+    @Before
+    public void setUp() {
+        controllerAdvice = new ComponentTraceControllerAdvice(mockRequestData);
+    }
+
+    @Test
+    public void supports_anyInput_true() {
+        assertThat(controllerAdvice.supports(ANY_RETURN_TYPE, ANY_CONVERTER_TYPE)).isTrue();
+    }
+
+    @Test
+    public void beforeBodyWrite_someBody_returnBody() {
+        Object expectedBody = "some body";
+        Object actualBody = controllerAdvice.beforeBodyWrite(expectedBody, ANY_RETURN_TYPE, ANY_MEDIA_TYPE, ANY_CONVERTER_TYPE, mockRequest, mockResponse);
+
+        assertThat(actualBody).isEqualTo(expectedBody);
+    }
+
+    @Test
+    public void beforeBodyWrite_anyResponse_addHeader() {
+        HttpHeaders someHeaders = new HttpHeaders();
+        someHeaders.add("any key", "any value");
+        given(mockResponse.getHeaders()).willReturn(someHeaders);
+
+        controllerAdvice.beforeBodyWrite("any body", ANY_RETURN_TYPE, ANY_MEDIA_TYPE, ANY_CONVERTER_TYPE, mockRequest, mockResponse);
+
+        then(mockRequestData).should().addComponentTraceHeader(someHeaders);
+    }
+}


### PR DESCRIPTION
Makes the audit-service append its own name to the x-component-trace header and return that header to the caller. Logic for this all taken from https://github.com/UKHomeOffice/pttg-ip-api/pull/205

As audit service isn't externally exposed I intend to merge once approved.