### PR TITLE
EE-6825 Add x-component-trace for add to archive.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,7 +16,7 @@ pipeline:
       - ./gradlew release -Prelease.useAutomaticVersion=true -x runBuildTasks
       - git describe --abbrev=0 --tags > ./tagSemver
     when:
-      branch: master
+      branch: [master, EE-6825-trace-header-on-add-to-audit]
       event: [push]
 
   docker-build:
@@ -111,7 +111,7 @@ pipeline:
       - cd kube-pttg-ip-audit
       - ./deploy.sh
     when:
-      branch: master
+      branch: [master, EE-6825-trace-header-on-add-to-audit]
       event: [push, tag]
 
   deployment-to-non-prod:

--- a/src/main/java/uk/gov/digital/ho/pttg/api/RequestData.java
+++ b/src/main/java/uk/gov/digital/ho/pttg/api/RequestData.java
@@ -5,6 +5,7 @@ import org.slf4j.MDC;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.util.WebUtils;
 
 import javax.servlet.http.HttpServletRequest;
@@ -47,6 +48,11 @@ public class RequestData implements HandlerInterceptor {
     private String initialiseRequestStart() {
         Long requestStart = Instant.now().toEpochMilli();
         return Long.toString(requestStart);
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+        response.addHeader(COMPONENT_TRACE_HEADER, componentTrace());
     }
 
     @Override

--- a/src/test/java/uk/gov/digital/ho/pttg/api/RequestDataTest.java
+++ b/src/test/java/uk/gov/digital/ho/pttg/api/RequestDataTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -133,5 +134,16 @@ public class RequestDataTest {
         requestData.addComponentTraceHeader(mockHeaders);
 
         then(mockHeaders).should().add(COMPONENT_TRACE_HEADER, expectedComponentTrace);
+    }
+
+    @Test
+    public void postHandle_someComponentTrace_addAsHeader() throws Exception {
+        String expectedComponentTrace = "pttg-ip-api,pttg-ip-audit";
+        MDC.put(COMPONENT_TRACE_HEADER, expectedComponentTrace);
+
+        ModelAndView mockModelAndView = mock(ModelAndView.class);
+        requestData.postHandle(mockRequest, mockResponse, mockHandler, mockModelAndView);
+
+        then(mockResponse).should().addHeader(COMPONENT_TRACE_HEADER, expectedComponentTrace);
     }
 }


### PR DESCRIPTION
I couldn't work out why the audit-service wasn't appearing in the component trace, even though I could see from logs that the service was being called. 

It turns out that the @ControllerAdvice which adds the x-component-trace header to the response only works on @RequestMapping methods that return an Object. The AuditResource add() method returns void. 

Adding a postHandle method to RequestData that adds the header fixes this. It's a bit naff having to have two routes for doing the same thing depending on the method's return type but I cannot find any better patterns. Although this change seems low risk I'll raise a JIRA to test nevertheless as I've changed behaviour. 