### PR TITLE
EE-34375: Removed unnecessary env var. 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -157,10 +157,9 @@ steps:
     KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
     PTTG_IP_DEV:
       from_secret: pttg_ip_dev
-    VERSION: ${IMAGE_VERSION}
   when:
     event:
-    - deployment
+    - promote
     target:
     - dev
     - test
@@ -178,10 +177,9 @@ steps:
     KUBE_SERVER: https://kube-api-prod.prod.acp.homeoffice.gov.uk
     PTTG_IP_PR:
       from_secret: pttg_ip_pr
-    VERSION: ${IMAGE_VERSION}
   when:
     event:
-    - deployment
+    - promote
     target:
     - pr
 


### PR DESCRIPTION
Use Drone v1 syntax (promote rather than deployment)